### PR TITLE
Use latest devicestatus basalUnitsPerDay in Day-to-day insulin totals

### DIFF
--- a/lib/report/reportclient.js
+++ b/lib/report/reportclient.js
@@ -694,7 +694,7 @@ var init = function init () {
           data.devicestatus = [];
           return $.Deferred().resolve();
         }
-        if (options.iob || options.cob || options.openAps || options.predicted) {
+        if (options.iob || options.cob || options.openAps || options.predicted || options.insulindistribution) {
           $('#info-' + day).html('<b>' + translate('Loading device status data of') + ' ' + day + ' ...</b>');
           var tquery = '?find[created_at][$gte]=' + new Date(from).toISOString() + '&find[created_at][$lt]=' + new Date(to).toISOString() + '&count=10000';
           return $.ajax('/api/v1/devicestatus.json' + tquery, {

--- a/lib/report_plugins/daytoday.js
+++ b/lib/report_plugins/daytoday.js
@@ -945,8 +945,15 @@ daytoday.report = function report_daytoday (datastorage, sorteddaystoshow, optio
         $('<tr><td>' + translate('Negative temp basal insulin:') + '</td><td align="right">' + negativeTemps.toFixed(1) + 'U</td></tr>').appendTo(table);
       }
       var totalBasalInsulin = baseBasalInsulin + positiveTemps + negativeTemps;
+      for (var statusIndex = data.devicestatus.length - 1; statusIndex >= 0; statusIndex--) {
+        var status = data.devicestatus[statusIndex];
+        if (status && status.pump && _.isFinite(Number(status.pump.basalUnitsPerDay))) {
+          totalBasalInsulin = Number(status.pump.basalUnitsPerDay);
+          break;
+        }
+      }
       $('<tr><td><b>' + translate('Total basal insulin:') + '</b></td><td align="right">' + totalBasalInsulin.toFixed(1) + 'U</td></tr>').appendTo(table);
-      var totalDailyInsulin = bolusInsulin + baseBasalInsulin + positiveTemps + negativeTemps;
+      var totalDailyInsulin = bolusInsulin + totalBasalInsulin;
       $('<tr><td><b>' + translate('Total daily insulin:') + '</b></td><td align="right">' + totalDailyInsulin.toFixed(1) + 'U</td></tr>').appendTo(table);
 
       $('<tr><td>' + translate('Total carbs') + ':</td><td align="right">' + data.dailyCarbs + ' g</td></tr>').appendTo(table);


### PR DESCRIPTION
### Motivation
- Make the Day-to-day report display the pump-reported `basalUnitsPerDay` from `/api/v1/devicestatus.json` as the day’s shown total basal insulin when available, so the reported basal total matches device state.
- Ensure the report can obtain devicestatus data when insulin distribution is enabled even if `iob`, `cob`, `openAps` or `predicted` options are not selected.

### Description
- Update `lib/report/reportclient.js` to include `options.insulindistribution` in the condition that loads `/api/v1/devicestatus.json` for a day so device statuses are fetched when insulin distribution is requested.
- Update `lib/report_plugins/daytoday.js` to walk the day’s `data.devicestatus` records from newest to oldest and use the first `status.pump.basalUnitsPerDay` value that is a finite number as `Total basal insulin` with a fallback to the previously computed `baseBasalInsulin + positiveTemps + negativeTemps`.
- Compute `Total daily insulin` as `bolusInsulin + totalBasalInsulin` so the total is consistent with the shown basal source, while keeping the temp/base basal breakdown rows unchanged.

### Testing
- Ran `npx eslint lib/report/reportclient.js lib/report_plugins/daytoday.js` which completed successfully.
- Ran `npm -s test` which failed in this environment due to a missing `./my.test.env` file, so full test suite could not be executed here.
- Attempted a Playwright screenshot of a local server but it failed with `ERR_EMPTY_RESPONSE` because no local webserver was available to render the report.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1ad23f510832dae6959227c5bbbfd)